### PR TITLE
Add heuristics to validate employee stock purchase plan (ESPP) gain

### DIFF
--- a/download_qst.py
+++ b/download_qst.py
@@ -24,7 +24,6 @@ def get_qlt_zip_url_from_2024(year: int) -> str:
 def main():
     args = parse_args()
 
-    # properly declare the dict above
     year_format_mapping = {
         2021: get_qlt_zip_url_pre_2024,
         2022: get_qlt_zip_url_pre_2024,

--- a/verify.py
+++ b/verify.py
@@ -446,9 +446,7 @@ class WagePayslip(Payslip):
         This method checks for the following three potential reported ESPP gain issues:
         1. The month IS January, April, July, or October, and ESPP gain is non-zero.
         2. The month IS NOT January, April, July, or October, and ESPP gain is zero (or missing).
-        3. The ESPP gain is larger than 10% of the max ESPP contribution (ignore exchange rate considerations)
-
-        Note: For heuristic #3, a warning will always be produced for a monthly gross income of over ~80000 CHF
+        3. The ESPP gain is larger than a 10% discount of the max ESPP contribution (ignore exchange rate considerations)
         """
         # validate ESPP gain
         espp_gain = self.get_val("ESPP gain")


### PR DESCRIPTION
Three checks have been added to detect the following potential reported ESPP gain issues:
1. The payslip month IS January, April, July, or October, and ESPP gain is non-zero.
2. The payslip month IS NOT January, April, July, or October, and ESPP gain is zero (or missing).
3. The ESPP gain is larger than a 10% discount of the max ESPP contribution (ignore exchange rate considerations)